### PR TITLE
Fix a memory leak and stuff

### DIFF
--- a/core/main.c
+++ b/core/main.c
@@ -103,6 +103,8 @@ U8 main(I32 argc, I8** argv) {
     FILE* fl = fopen(filename, "rb");
     if (fl == NULL) {
       fprintf(stderr, "gc24: \033[91mfatal error:\033[0m file `%s` not found\n", filename);
+      free(gc.mem);
+      free(gc.rom);
       old_st;
       return 1;
     }

--- a/core/main.c
+++ b/core/main.c
@@ -103,9 +103,9 @@ U8 main(I32 argc, I8** argv) {
     FILE* fl = fopen(filename, "rb");
     if (fl == NULL) {
       fprintf(stderr, "gc24: \033[91mfatal error:\033[0m file `%s` not found\n", filename);
+      old_st;
       free(gc.mem);
       free(gc.rom);
-      old_st;
       return 1;
     }
     fread(gc.mem+0x030000, 1, MEMSIZE, fl);

--- a/lib/cpu24/cli.h
+++ b/lib/cpu24/cli.h
@@ -83,9 +83,11 @@ U8 ExecD(GC* gc, U8 trapped) {
   }
   switch ((*tokens)[0]) {
   case 'q':
+    free(buf);
     if (trapped) exit(0);
     return 0;
   case 'R':
+    free(buf);
     return EXEC_START;
   case 'r':
     cli_DisplayReg(gc);


### PR DESCRIPTION
Fixes a memory leak in lib/cpu24/cli.h:64 (ExecD)
Valgrind logs now:
```
$ valgrind --leak-check=full ./gc24 a
==4501== Memcheck, a memory error detector
==4501== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==4501== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==4501== Command: ./gc24 a
==4501== 
==4501== Syscall param read(buf) points to unaddressable byte(s)
==4501==    at 0x4BE8E56: __internal_syscall_cancel (cancellation.c:64)
==4501==    by 0x4BE8E73: __syscall_cancel (cancellation.c:75)
==4501==    by 0x4C63A3D: read (read.c:26)
==4501==    by 0x4BE4EBA: _IO_file_xsgetn (fileops.c:1343)
==4501==    by 0x4BD7ABF: fread (iofread.c:38)
==4501==    by 0x1134D1: main (in /home/aceinet/gc24/gc24)
==4501==  Address 0x5d4b040 is 0 bytes after a block of size 16,777,216 alloc'd
==4501==    at 0x48457A8: malloc (vg_replace_malloc.c:446)
==4501==    by 0x10D5A7: InitGC (in /home/aceinet/gc24/gc24)
==4501==    by 0x1133CA: main (in /home/aceinet/gc24/gc24)
==4501== 

trapped at PC$03000A
: R
gc24: executed 5 instructions
==4501== 
==4501== HEAP SUMMARY:
==4501==     in use at exit: 418,374 bytes in 3,601 blocks
==4501==   total heap usage: 170,860 allocs, 167,259 frees, 72,767,947 bytes allocated
==4501== 
==4501== LEAK SUMMARY:
==4501==    definitely lost: 0 bytes in 0 blocks
==4501==    indirectly lost: 0 bytes in 0 blocks
==4501==      possibly lost: 0 bytes in 0 blocks
==4501==    still reachable: 418,342 bytes in 3,600 blocks
==4501==         suppressed: 32 bytes in 1 blocks
==4501== Reachable blocks (those to which a pointer was found) are not shown.
==4501== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==4501== 
==4501== For lists of detected and suppressed errors, rerun with: -s
==4501== ERROR SUMMARY: 2 errors from 1 contexts (suppressed: 0 from 0)
```

There are still many memory leaks, but that's something at least

EDIT: Fixed another memory leak, caused by main.c:100 :)